### PR TITLE
MidiSynthExample: use N low latency APIs

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="Android API 23 Platform" project-jdk-type="Android SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="Android API 23 Platform" project-jdk-type="Android SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/MidiSynthExample/AndroidManifest.xml
+++ b/MidiSynthExample/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <uses-sdk
         android:minSdkVersion="23"
-        android:targetSdkVersion="N" />
+        android:targetSdkVersion="23" />
 
     <uses-feature android:name="android.software.midi" android:required="true"/>
 

--- a/MidiSynthExample/AndroidManifest.xml
+++ b/MidiSynthExample/AndroidManifest.xml
@@ -16,12 +16,12 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.mobileer.midisynthexample"
-        android:versionCode="2"
-        android:versionName="1.1">
+        android:versionCode="3"
+        android:versionName="1.2">
 
     <uses-sdk
         android:minSdkVersion="23"
-        android:targetSdkVersion="23" />
+        android:targetSdkVersion="N" />
 
     <uses-feature android:name="android.software.midi" android:required="true"/>
 

--- a/MidiSynthExample/res/layout/main.xml
+++ b/MidiSynthExample/res/layout/main.xml
@@ -36,6 +36,40 @@
         android:entries="@array/senders"
         />
 
+    <LinearLayout
+        android:id="@+id/layout_latency"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <CheckBox
+            android:id="@+id/checkbox_low_latency"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="FLAG_LOW_LATENCY"
+            android:onClick="onToggleLowLatency"
+            style="@android:style/TextAppearance.Large"
+            />
+
+        <CheckBox
+            android:id="@+id/checkbox_optimize"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Optimize Buffer Size"
+            android:onClick="onToggleAutoSize"
+            style="@android:style/TextAppearance.Large"
+            />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/text_latency"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@android:style/TextAppearance.Large"
+        android:text="xyz"
+        />
+
     <CheckBox
         android:id="@+id/lock_screen_checkbox"
         android:layout_width="wrap_content"

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
@@ -1,0 +1,82 @@
+package com.mobileer.midisynthexample;
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.app.Instrumentation;
+import android.util.Log;
+import android.view.KeyEvent;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Generate fake key events so that the CPU speed will not get lowered.
+ * This is useful if you are using a MIDI keyboard and no touching the screen.
+ */
+public class FakeKeyGenerator {
+    public static final String TAG = "FakeKeyGenerator";
+    private Timer mFakeKeyTimer;
+    private FakeKeyTimerTask mFakeKeyTask;
+
+    static class FakeKeyTimerTask extends TimerTask {
+        @Override
+        public void run() {
+            sendFakeKeyEvent();
+        }
+    };
+
+    /**
+     * Post fake key event to keep CPU from throttling down.
+     * This should be called at least once per second.
+     * It should NOT be called on the UI thread!
+     */
+    public static void sendFakeKeyEvent() {
+        try {
+            Instrumentation instrumentation = new Instrumentation();
+            instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_BACKSLASH);
+        } catch(SecurityException e) {
+            // Even though I was honoring window focus, I was still getting these exceptions.
+            Log.e(TAG, "sendFakeKeyEvent() was out of focus");
+        }
+    }
+
+    /**
+     * Start a timer task that periodically generates a fake key input event.
+     */
+    public void start() {
+        stop(); // just in case start() is called twice in a row
+        mFakeKeyTimer = new Timer();
+        mFakeKeyTask = new FakeKeyTimerTask();
+        mFakeKeyTimer.schedule(mFakeKeyTask, 1000, 1000);
+    }
+
+    /**
+     * Stop the fake key timer task if running.
+     */
+    public void stop() {
+        // Cancel the fake key events.
+        if (mFakeKeyTimer != null) {
+            mFakeKeyTimer.cancel();
+            mFakeKeyTimer.purge();
+            mFakeKeyTimer = null;
+        }
+        if (mFakeKeyTask != null){
+            mFakeKeyTask.cancel();
+            mFakeKeyTask = null;
+        }
+    }
+
+}

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
@@ -24,12 +24,14 @@ import java.util.TimerTask;
 
 /**
  * Generate fake key events so that the CPU speed will not get lowered.
- * This is useful if you are using a MIDI keyboard and no touching the screen.
+ * This is useful if you are using a MIDI keyboard and not touching the screen.
  */
 public class FakeKeyGenerator {
     public static final String TAG = "FakeKeyGenerator";
+    public static final int FAKE_KEY = KeyEvent.KEYCODE_BACKSLASH;
     private Timer mFakeKeyTimer;
     private FakeKeyTimerTask mFakeKeyTask;
+    private static Instrumentation instrumentation = new Instrumentation();
 
     static class FakeKeyTimerTask extends TimerTask {
         @Override
@@ -45,8 +47,7 @@ public class FakeKeyGenerator {
      */
     public static void sendFakeKeyEvent() {
         try {
-            Instrumentation instrumentation = new Instrumentation();
-            instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_BACKSLASH);
+            instrumentation.sendKeyDownUpSync(FAKE_KEY);
         } catch(SecurityException e) {
             // Even though I was honoring window focus, I was still getting these exceptions.
             Log.e(TAG, "sendFakeKeyEvent() was out of focus");

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/MidiSynthDeviceService.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/MidiSynthDeviceService.java
@@ -16,20 +16,39 @@
 
 package com.mobileer.midisynthexample;
 
+import android.content.Context;
+import android.media.AudioManager;
 import android.media.midi.MidiDeviceService;
 import android.media.midi.MidiDeviceStatus;
 import android.media.midi.MidiReceiver;
 
+import com.mobileer.miditools.synth.LatencyController;
 import com.mobileer.miditools.synth.SynthEngine;
 
 public class MidiSynthDeviceService extends MidiDeviceService {
     private static final String TAG = MainActivity.TAG;
-    private SynthEngine mSynthEngine = new SynthEngine();
+    private static SynthEngine mSynthEngine = new SynthEngine();
     private boolean mSynthStarted = false;
+    private int mFramesPerBlock;
+    private static MidiSynthDeviceService mInstance;
 
     @Override
     public void onCreate() {
         super.onCreate();
+        mInstance = this;
+        queryOptimalAudioSettings();
+    }
+
+    // Query the system for the best sample rate and buffer size for low latency.
+    public void queryOptimalAudioSettings() {
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+     //   String text = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
+     //   mSampleRate = Integer.parseInt(text);
+     //TODO   mSynthEngine.setSampleRate(mSampleRate);
+        String text = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
+        mFramesPerBlock = 64; //TODO HACK - Integer.parseInt(text);
+
+        mSynthEngine.setFramesPerBlock(mFramesPerBlock);
     }
 
     @Override
@@ -57,4 +76,11 @@ public class MidiSynthDeviceService extends MidiDeviceService {
         }
     }
 
+    public static LatencyController getLatencyController() {
+        return mSynthEngine.getLatencyController();
+    }
+
+    public static int getMidiByteCount() {
+        return mSynthEngine.getMidiByteCount();
+    }
 }

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/MidiSynthDeviceService.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/MidiSynthDeviceService.java
@@ -29,7 +29,6 @@ public class MidiSynthDeviceService extends MidiDeviceService {
     private static final String TAG = MainActivity.TAG;
     private static SynthEngine mSynthEngine = new SynthEngine();
     private boolean mSynthStarted = false;
-    private int mFramesPerBlock;
     private static MidiSynthDeviceService mInstance;
 
     @Override
@@ -42,13 +41,9 @@ public class MidiSynthDeviceService extends MidiDeviceService {
     // Query the system for the best sample rate and buffer size for low latency.
     public void queryOptimalAudioSettings() {
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-     //   String text = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
-     //   mSampleRate = Integer.parseInt(text);
-     //TODO   mSynthEngine.setSampleRate(mSampleRate);
         String text = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
-        mFramesPerBlock = 64; //TODO HACK - Integer.parseInt(text);
-
-        mSynthEngine.setFramesPerBlock(mFramesPerBlock);
+        int framesPerBlock = Integer.parseInt(text);
+        mSynthEngine.setFramesPerBlock(framesPerBlock);
     }
 
     @Override

--- a/MidiTools/src/com/mobileer/miditools/synth/AudioLatencyTuner.java
+++ b/MidiTools/src/com/mobileer/miditools/synth/AudioLatencyTuner.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.miditools.synth;
+
+import android.media.AudioAttributes;
+import android.media.AudioTrack;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Optimize the buffer size for an AudioTrack based on the underrun count.
+ * <p/>
+ * This feature was added in N. So we check for the methods using reflection.
+ */
+public class AudioLatencyTuner {
+    private static final String TAG = "AudioLatencyTuner";
+    private static boolean lowLatencySupported;
+    private static final int STATE_PRIMING = 0;
+    private static final int STATE_LOWERING = 1;
+    private static final int STATE_RAISING = 2;
+
+    // These are found using reflection.
+    private static int mFlagLowLatency; // AudioAttributes.FLAG_LOW_LATENCY
+    private static Method mSetBufferSizeMethod = null;
+    private static Method mGetBufferCapacityMethod = null;
+    private static Method mGetUnderrunCountMethod = null;
+
+    private final int mInitialSize;
+    private int mState = STATE_PRIMING;
+    private AudioTrack mAudioTrack;
+    private int mPreviousUnderrunCount;
+    private int mFramesPerBlock = 64;
+
+    static {
+        reflectAdvancedMethods();
+    }
+
+    public AudioLatencyTuner(AudioTrack track) {
+        mAudioTrack = track;
+        mInitialSize = track.getBufferSizeInFrames();
+    }
+
+    /**
+     * Use Java reflection to find the methods added in the N release.
+     */
+    private static void reflectAdvancedMethods() {
+        try {
+            Field field = AudioAttributes.class.getField("FLAG_LOW_LATENCY");
+            mFlagLowLatency = field.getInt(AudioAttributes.class);
+            lowLatencySupported = true;
+        } catch (NoSuchFieldException e) {
+            lowLatencySupported = false;
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        Method[] methods = AudioTrack.class.getMethods();
+
+        for (Method method : methods) {
+            if (method.getName().equals("setBufferSizeInFrames")) {
+                mSetBufferSizeMethod = method;
+                break;
+            }
+        }
+
+        for (Method method : methods) {
+            if (method.getName().equals("getBufferCapacityInFrames")) {
+                mGetBufferCapacityMethod = method;
+                break;
+            }
+        }
+
+        for (Method method : methods) {
+            if (method.getName().equals("getUnderrunCount")) {
+                mGetUnderrunCountMethod = method;
+                break;
+            }
+        }
+    }
+
+    /**
+     * @return number of times the audio buffer underflowed and glitched.
+     */
+    public int getUnderrunCount() {
+        // Call using reflection.
+        if (mGetUnderrunCountMethod != null && mAudioTrack != null) {
+            try {
+                Object result = mGetUnderrunCountMethod.invoke(mAudioTrack);
+                int count = ((Integer) result).intValue();
+                return count;
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * @return allocated size of the buffer
+     */
+    public int getBufferCapacityInFrames() {
+        if (mGetBufferCapacityMethod != null) {
+            try {
+                Object result = mGetBufferCapacityMethod.invoke(mAudioTrack);
+                int size = ((Integer) result).intValue();
+                return size;
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+        return mInitialSize;
+    }
+
+    /**
+     * Set the amount of the buffer capacity that we want to use.
+     * Lower values will reduce latency but may cause glitches.
+     * Note that you may not get the size you asked for.
+     *
+     * @return actual size of the buffer
+     */
+    public int setBufferSizeInFrames(int thresholdFrames) {
+        if (mSetBufferSizeMethod != null) {
+            try {
+                Object result = mSetBufferSizeMethod.invoke(mAudioTrack, thresholdFrames);
+                int actual = ((Integer) result).intValue();
+                Log.i(TAG, "setThresholdInFrames(" + thresholdFrames + ") returned " + actual);
+                return actual;
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+        return mInitialSize;
+    }
+
+    public void setFramesPerBlock(int framesPerBlock) {
+        mFramesPerBlock = framesPerBlock;
+    }
+
+    public int getBufferSizeInFrames() {
+        return mAudioTrack.getBufferSizeInFrames();
+    }
+
+    public static boolean isLowLatencySupported() {
+        return lowLatencySupported;
+    }
+
+    public static int getLowLatencyFlag() {
+        return mFlagLowLatency;
+    }
+
+    public void reset() {
+        if (!lowLatencySupported) {
+            return;
+        }
+        mState = STATE_PRIMING;
+        setBufferSizeInFrames(mInitialSize);
+    }
+
+    /**
+     * This should be called after every write().
+     * It will lower the latency until there are underruns.
+     * Then it raises the latency until the underruns stop.
+     */
+    public void update() {
+        if (!lowLatencySupported) {
+            return;
+        }
+        int nextState = mState;
+        int underrunCount;
+        switch (mState) {
+            case STATE_PRIMING:
+                if (mAudioTrack.getPlaybackHeadPosition() > (8 * mFramesPerBlock)) {
+                    nextState = STATE_LOWERING;
+                    mPreviousUnderrunCount = getUnderrunCount();
+                }
+                break;
+            case STATE_LOWERING:
+                underrunCount = getUnderrunCount();
+                if (underrunCount > mPreviousUnderrunCount) {
+                    nextState = STATE_RAISING;
+                } else {
+                    if (incrementThreshold(-1)) {
+                        // If we hit bottom then start raising it back up.
+                        nextState = STATE_RAISING;
+                    }
+                }
+                mPreviousUnderrunCount = underrunCount;
+                break;
+            case STATE_RAISING:
+                underrunCount = getUnderrunCount();
+                if (underrunCount > mPreviousUnderrunCount) {
+                    incrementThreshold(1);
+                }
+                mPreviousUnderrunCount = underrunCount;
+                break;
+        }
+        mState = nextState;
+    }
+
+    private boolean incrementThreshold(int delta) {
+        int original = getBufferSizeInFrames();
+        int numBlocks = original / mFramesPerBlock;
+        numBlocks += delta;
+        int target = numBlocks * mFramesPerBlock;
+        int actual = setBufferSizeInFrames(target);
+        Log.i(TAG, "Threshold changed from " + original + " to " + actual);
+        return actual == original;
+    }
+
+}

--- a/MidiTools/src/com/mobileer/miditools/synth/EnvelopeADSR.java
+++ b/MidiTools/src/com/mobileer/miditools/synth/EnvelopeADSR.java
@@ -36,24 +36,28 @@ public class EnvelopeADSR extends SynthUnit {
     private float mDecayRate;
     private float mCurrent;
     private int mSstate = IDLE;
+    private int mSamplerate;
 
-    public EnvelopeADSR() {
+    public EnvelopeADSR( int sampleRate) {
+        mSamplerate = sampleRate;
         setAttackTime(0.003f);
         setDecayTime(0.08f);
         setSustainLevel(0.3f);
         setReleaseTime(1.0f);
     }
 
+
+
     public void setAttackTime(float time) {
         if (time < MIN_TIME)
             time = MIN_TIME;
-        mAttackRate = 1.0f / (SynthEngine.FRAME_RATE * time);
+        mAttackRate = 1.0f / (mSamplerate * time);
     }
 
     public void setDecayTime(float time) {
         if (time < MIN_TIME)
             time = MIN_TIME;
-        mDecayRate = 1.0f / (SynthEngine.FRAME_RATE * time);
+        mDecayRate = 1.0f / (mSamplerate * time);
     }
 
     public void setSustainLevel(float level) {
@@ -65,7 +69,7 @@ public class EnvelopeADSR extends SynthUnit {
     public void setReleaseTime(float time) {
         if (time < MIN_TIME)
             time = MIN_TIME;
-        mRreleaseRate = 1.0f / (SynthEngine.FRAME_RATE * time);
+        mRreleaseRate = 1.0f / (mSamplerate * time);
     }
 
     public void on() {

--- a/MidiTools/src/com/mobileer/miditools/synth/LatencyController.java
+++ b/MidiTools/src/com/mobileer/miditools/synth/LatencyController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.miditools.synth;
+
+/**
+ * Abstract control over the audio latency.
+ */
+public abstract class LatencyController {
+    private boolean mLowLatencyEnabled;
+    private boolean mAutoSizeEnabled;
+
+    public void setLowLatencyEnabled(boolean enabled) {
+        mLowLatencyEnabled = enabled;
+    }
+
+    public boolean isLowLatencyEnabled() {
+        return mLowLatencyEnabled;
+    }
+
+    /**
+     * If true then adjust latency to lowest value that does not produce underruns.
+     *
+     * @param enabled
+     */
+    public void setAutoSizeEnabled(boolean enabled) {
+        mAutoSizeEnabled = enabled;
+    }
+
+    public boolean isAutoSizeEnabled() {
+        return mAutoSizeEnabled;
+    }
+
+    /**
+     * @return true if this version supports the LOW_LATENCY flag
+     */
+    public abstract boolean isLowLatencySupported();
+
+    /**
+     * The amount of the buffer capacity that is being used.
+     * @return
+     */
+    public abstract int getBufferSizeInFrames();
+
+    /**
+     * The allocated size of the buffer.
+     * @return
+     */
+    public abstract int getBufferCapacityInFrames();
+
+    public abstract int getUnderrunCount();
+
+    /**
+     * When the output is running, the LOW_LATENCY flag cannot be set.
+     * @return
+     */
+    public abstract boolean isRunning();
+
+    /**
+     * Calculate the percentage of time that the a CPU is calculating data.
+     * @return percent CPU load
+     */
+    public abstract int getCpuLoad();
+}

--- a/MidiTools/src/com/mobileer/miditools/synth/SawVoice.java
+++ b/MidiTools/src/com/mobileer/miditools/synth/SawVoice.java
@@ -23,9 +23,9 @@ public class SawVoice extends SynthVoice {
     private SawOscillator mOscillator;
     private EnvelopeADSR mEnvelope;
 
-    public SawVoice() {
+    public SawVoice(int sampleRate) {
         mOscillator = createOscillator();
-        mEnvelope = new EnvelopeADSR();
+        mEnvelope = new EnvelopeADSR(sampleRate);
     }
 
     protected SawOscillator createOscillator() {

--- a/MidiTools/src/com/mobileer/miditools/synth/SimpleAudioOutput.java
+++ b/MidiTools/src/com/mobileer/miditools/synth/SimpleAudioOutput.java
@@ -16,9 +16,11 @@
 
 package com.mobileer.miditools.synth;
 
+import android.annotation.TargetApi;
+import android.media.AudioAttributes;
 import android.media.AudioFormat;
-import android.media.AudioManager;
 import android.media.AudioTrack;
+import android.os.Build;
 import android.util.Log;
 
 /**
@@ -27,60 +29,165 @@ import android.util.Log;
  */
 public class SimpleAudioOutput {
 
-    private static final String TAG = "AudioOutputTrack";
+    private static final String TAG = "SimpleAudioOutput";
     public static final int SAMPLES_PER_FRAME = 2;
     public static final int BYTES_PER_SAMPLE = 4; // float
     public static final int BYTES_PER_FRAME = SAMPLES_PER_FRAME * BYTES_PER_SAMPLE;
+    private static final int AVERAGING_FACTOR = 31;
+
     private AudioTrack mAudioTrack;
     private int mFrameRate;
+    private AudioLatencyTuner mLatencyTuner;
+    private MyLatencyController mLatencyController = new MyLatencyController();
+    private long previousBeginTime;
+    private volatile long filteredCpuInterval;
+    private volatile long filteredTotalInterval;
 
-    /**
-     *
-     */
-    public SimpleAudioOutput() {
-        super();
+    class MyLatencyController extends LatencyController
+    {
+        @Override
+        public boolean isLowLatencySupported() {
+            return AudioLatencyTuner.isLowLatencySupported();
+        }
+
+        @Override
+        public boolean isRunning() {
+            return mAudioTrack != null;
+        }
+
+        public void setAutoSizeEnabled(boolean enabled) {
+            super.setAutoSizeEnabled(enabled);
+            if (!enabled) {
+                AudioLatencyTuner tuner = mLatencyTuner;
+                if (tuner != null) {
+                    tuner.reset();
+                }
+            }
+        }
+
+        @Override
+        public int getBufferSizeInFrames() {
+            AudioTrack track = mAudioTrack;
+            if (track != null) {
+                return track.getBufferSizeInFrames();
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int getBufferCapacityInFrames() {
+            AudioLatencyTuner tuner = mLatencyTuner;
+            if (tuner != null) {
+                return tuner.getBufferCapacityInFrames();
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int getUnderrunCount() {
+            AudioLatencyTuner tuner = mLatencyTuner;
+            if (tuner != null) {
+                return tuner.getUnderrunCount();
+            } else {
+                return 0;
+            }
+        }
+
+
+        @Override
+        public int getCpuLoad() {
+            int load = 0;
+            if (filteredTotalInterval > 0) {
+                load = (int) ((filteredCpuInterval * 100) / filteredTotalInterval);
+            }
+            return load;
+        }
     }
 
     /**
      * Create an audio track then call play().
-     *
-     * @param frameRate
      */
-    public void start(int frameRate) {
+    public void start(int framesPerBlock) {
         stop();
-        mFrameRate = frameRate;
-        mAudioTrack = createAudioTrack(frameRate);
+        mAudioTrack = createAudioTrack();
+        mFrameRate = mAudioTrack.getSampleRate();
+        mLatencyTuner.setFramesPerBlock(framesPerBlock);
         // AudioTrack will wait until it has enough data before starting.
         mAudioTrack.play();
+        previousBeginTime = 0;
+        filteredCpuInterval = 0;
+        filteredTotalInterval = 0;
     }
 
-    public AudioTrack createAudioTrack(int frameRate) {
-        int minBufferSizeBytes = AudioTrack.getMinBufferSize(frameRate,
-                AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_FLOAT);
-        Log.i(TAG, "AudioTrack.minBufferSize = " + minBufferSizeBytes
-                + " bytes = " + (minBufferSizeBytes / BYTES_PER_FRAME)
-                + " frames");
-        int bufferSize = 8 * minBufferSizeBytes / 8;
-        int outputBufferSizeFrames = bufferSize / BYTES_PER_FRAME;
-        Log.i(TAG, "actual bufferSize = " + bufferSize + " bytes = "
-                + outputBufferSizeFrames + " frames");
+    @TargetApi(Build.VERSION_CODES.M)
+    protected AudioTrack createAudioTrack() {
+        AudioAttributes.Builder attributesBuilder = new AudioAttributes.Builder()
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC);
+        int bufferSizeInFrames = 128 * 3;
+        if (AudioLatencyTuner.isLowLatencySupported()
+                && mLatencyController.isLowLatencyEnabled()) {
+            Log.i(TAG, "createAudioTrack() using FLAG_LOW_LATENCY");
+            attributesBuilder.setFlags(AudioLatencyTuner.getLowLatencyFlag());
+            // Start with a bigger buffer because we can lower it later.
+            bufferSizeInFrames = 512 * 3;
+        }
+        AudioAttributes attributes = attributesBuilder.build();
 
-        AudioTrack player = new AudioTrack(AudioManager.STREAM_MUSIC,
-                mFrameRate, AudioFormat.CHANNEL_OUT_STEREO,
-                AudioFormat.ENCODING_PCM_FLOAT, bufferSize,
-                AudioTrack.MODE_STREAM);
-        Log.i(TAG, "created AudioTrack");
-        return player;
+        AudioFormat format = new AudioFormat.Builder()
+                .setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+                .build();
+        AudioTrack track = new AudioTrack.Builder()
+                .setAudioAttributes(attributes)
+                .setAudioFormat(format)
+                .setBufferSizeInBytes(bufferSizeInFrames * BYTES_PER_FRAME)
+                .build();
+        if (track == null) {
+            throw new RuntimeException("Could not make the Audio Track! attributes = "
+                    + attributes + ", format = " + format);
+        }
+        mLatencyTuner = new AudioLatencyTuner(track);
+        return track;
     }
 
     public int write(float[] buffer, int offset, int length) {
-        return mAudioTrack.write(buffer, offset, length,
+        endCpuLoadInterval();
+        int result = mAudioTrack.write(buffer, offset, length,
                 AudioTrack.WRITE_BLOCKING);
+        beginCpuLoadInterval();
+        if (result > 0 && mLatencyController.isAutoSizeEnabled()) {
+            mLatencyTuner.update();
+        }
+        return result;
+    }
+
+    private void endCpuLoadInterval() {
+        long now = System.nanoTime();
+        if (previousBeginTime > 0) {
+            long elapsed = now - previousBeginTime;
+            // recursive low pass filter
+            filteredCpuInterval = ((filteredCpuInterval * AVERAGING_FACTOR) + elapsed)
+                    / (AVERAGING_FACTOR + 1);
+        }
+
+    }
+    private void beginCpuLoadInterval() {
+        long now = System.nanoTime();
+        if (previousBeginTime > 0) {
+            long elapsed = now - previousBeginTime;
+            // recursive low pass filter
+            filteredTotalInterval = ((filteredTotalInterval * AVERAGING_FACTOR) + elapsed)
+                    / (AVERAGING_FACTOR + 1);
+        }
+        previousBeginTime = now;
     }
 
     public void stop() {
         if (mAudioTrack != null) {
             mAudioTrack.stop();
+            mAudioTrack.release();
             mAudioTrack = null;
         }
     }
@@ -89,7 +196,7 @@ public class SimpleAudioOutput {
         return mFrameRate;
     }
 
-    public AudioTrack getAudioTrack() {
-        return mAudioTrack;
+    public LatencyController getLatencyController() {
+        return mLatencyController;
     }
 }

--- a/MidiTools/src/com/mobileer/miditools/synth/SineVoice.java
+++ b/MidiTools/src/com/mobileer/miditools/synth/SineVoice.java
@@ -20,6 +20,10 @@ package com.mobileer.miditools.synth;
  * Replace sawtooth with a sine wave.
  */
 public class SineVoice extends SawVoice {
+    public SineVoice(int sampleRate) {
+        super(sampleRate);
+    }
+
     @Override
     protected SawOscillator createOscillator() {
         return new SineOscillator();


### PR DESCRIPTION
Optimize buffer size to get close to native latency.

This modification shows how to use the AudioAttributes.FLAG_LOW_LATENCY to reduce
latency. It also shows how to use AudioTrack.setBufferSizeInFrames() and getUnderrunCount() to tune the buffer for optimal latency.

