### PR TITLE
Unregister device callbacks when screen rotated.

### DIFF
--- a/MidiScope/src/com/mobileer/example/midiscope/MainActivity.java
+++ b/MidiScope/src/com/mobileer/example/midiscope/MainActivity.java
@@ -72,7 +72,7 @@ public class MainActivity extends Activity implements ScopeLogger {
         mLogSenderSelector = new MidiOutputPortSelector(mMidiManager, this,
                 R.id.spinner_senders) {
 
-                @Override
+            @Override
             public void onPortSelected(final MidiPortWrapper wrapper) {
                 super.onPortSelected(wrapper);
                 if (wrapper != null) {

--- a/MidiSynthExample/AndroidManifest.xml
+++ b/MidiSynthExample/AndroidManifest.xml
@@ -17,7 +17,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.mobileer.midisynthexample"
         android:versionCode="4"
-        android:versionName="1.3">
+        android:versionName="@string/versionName">
 
     <uses-sdk
         android:minSdkVersion="23"

--- a/MidiSynthExample/AndroidManifest.xml
+++ b/MidiSynthExample/AndroidManifest.xml
@@ -16,8 +16,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.mobileer.midisynthexample"
-        android:versionCode="3"
-        android:versionName="1.2">
+        android:versionCode="4"
+        android:versionName="1.3">
 
     <uses-sdk
         android:minSdkVersion="23"

--- a/MidiSynthExample/res/layout/main.xml
+++ b/MidiSynthExample/res/layout/main.xml
@@ -21,6 +21,13 @@
     >
 
     <TextView
+        android:id="@+id/text_version"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/versionName"
+        />
+
+    <TextView
         android:id="@+id/text_receivers"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/MidiSynthExample/res/values/strings.xml
+++ b/MidiSynthExample/res/values/strings.xml
@@ -16,6 +16,7 @@
 
 <resources>
 
+    <string name="versionName">1.3</string>
     <string name="synth_sender_text">Select Sender for Synth</string>
     <string name="error_port_busy">Selected port is in use or unavailable.</string>
     <string name="port_open_ok">Port opened OK.</string>

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
@@ -16,6 +16,7 @@ package com.mobileer.midisynthexample;
  */
 
 import android.app.Instrumentation;
+import android.media.midi.MidiManager;
 import android.util.Log;
 import android.view.KeyEvent;
 
@@ -29,9 +30,12 @@ import java.util.TimerTask;
 public class FakeKeyGenerator {
     public static final String TAG = "FakeKeyGenerator";
     public static final int FAKE_KEY = KeyEvent.KEYCODE_BACKSLASH;
+
+    private static FakeKeyGenerator mInstance;
+    private static Instrumentation instrumentation = new Instrumentation();
+
     private Timer mFakeKeyTimer;
     private FakeKeyTimerTask mFakeKeyTask;
-    private static Instrumentation instrumentation = new Instrumentation();
 
     static class FakeKeyTimerTask extends TimerTask {
         @Override
@@ -40,18 +44,20 @@ public class FakeKeyGenerator {
         }
     };
 
+    public static FakeKeyGenerator getInstance() {
+        if (mInstance == null) {
+            mInstance = new FakeKeyGenerator();
+        }
+        return mInstance;
+    }
+
     /**
      * Post fake key event to keep CPU from throttling down.
      * This should be called at least once per second.
      * It should NOT be called on the UI thread!
      */
     public static void sendFakeKeyEvent() {
-        try {
-            instrumentation.sendKeyDownUpSync(FAKE_KEY);
-        } catch(SecurityException e) {
-            // Even though I was honoring window focus, I was still getting these exceptions.
-            Log.e(TAG, "sendFakeKeyEvent() was out of focus");
-        }
+        instrumentation.sendKeyDownUpSync(FAKE_KEY);
     }
 
     /**

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/FakeKeyGenerator.java
@@ -24,8 +24,14 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 /**
- * Generate fake key events so that the CPU speed will not get lowered.
- * This is useful if you are using a MIDI keyboard and not touching the screen.
+ * Generate fake key events so that the CPU speed will not get lowered
+ * when the user is not touching the screen.
+ *
+ * This is useful if you are using a MIDI keyboard to control a synthesizer
+ * running on Android.
+ *
+ * This class uses the Singleton design pattern because there is no need
+ * to have more than one generator and only one View can have focus.
  */
 public class FakeKeyGenerator {
     public static final String TAG = "FakeKeyGenerator";
@@ -44,7 +50,11 @@ public class FakeKeyGenerator {
         }
     };
 
-    public static FakeKeyGenerator getInstance() {
+    // Prevent direct instantiation of this Singleton.
+    private FakeKeyGenerator() {
+    }
+
+    public synchronized static FakeKeyGenerator getInstance() {
         if (mInstance == null) {
             mInstance = new FakeKeyGenerator();
         }
@@ -62,6 +72,7 @@ public class FakeKeyGenerator {
 
     /**
      * Start a timer task that periodically generates a fake key input event.
+     * This should be called on the UI thread, usually from onWindowFocusChanged().
      */
     public void start() {
         stop(); // just in case start() is called twice in a row
@@ -72,6 +83,7 @@ public class FakeKeyGenerator {
 
     /**
      * Stop the fake key timer task if running.
+     * This should be called on the UI thread, usually from onWindowFocusChanged().
      */
     public void stop() {
         // Cancel the fake key events.

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/MainActivity.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/MainActivity.java
@@ -17,6 +17,7 @@
 package com.mobileer.midisynthexample;
 
 import android.app.Activity;
+import android.app.Fragment;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.media.midi.MidiDevice.MidiConnection;
@@ -32,6 +33,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.mobileer.miditools.MidiDeviceMonitor;
 import com.mobileer.miditools.MidiOutputPortConnectionSelector;
 import com.mobileer.miditools.MidiPortConnector;
 import com.mobileer.miditools.MidiTools;
@@ -51,7 +53,6 @@ public class MainActivity extends Activity {
     private Handler mLatencyHandler;
     private CheckBox mLatencyCheckBox;
     private CheckBox mOptimizeSizeCheckBox;
-    private FakeKeyGenerator mFakeKeyGenerator;
 
     private Runnable mLatencyRunnable = new Runnable() {
         @Override
@@ -67,10 +68,6 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.main);
-
-        // Lock to portrait to avoid onCreate being called more than once.
-        // TODO Use a Fragment to handle this more gracefully.
- //       setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
         mLatencyCheckBox = (CheckBox) findViewById(R.id.checkbox_low_latency);
         mOptimizeSizeCheckBox = (CheckBox) findViewById(R.id.checkbox_optimize);
@@ -90,9 +87,6 @@ public class MainActivity extends Activity {
 
         // Create the Handler object (on the main thread by default)
         mLatencyHandler = new Handler();
-
-        // Generate fake key events to keep CPU from being slowed down.
-        mFakeKeyGenerator = new FakeKeyGenerator();
 
         // Is Android MIDI supported?
         if (getPackageManager().hasSystemFeature(PackageManager.FEATURE_MIDI)) {
@@ -127,11 +121,11 @@ public class MainActivity extends Activity {
             // Start updating the latency view.
             mLatencyHandler.post(mLatencyRunnable);
             // Start generating fake key events.
-            mFakeKeyGenerator.start();
+            FakeKeyGenerator.getInstance().start();
         } else {
             // Stop the background tasks.
             mLatencyHandler.removeCallbacks(mLatencyRunnable);
-            mFakeKeyGenerator.stop();
+            FakeKeyGenerator.getInstance().stop();
         }
     }
 

--- a/MidiSynthExample/src/com/mobileer/midisynthexample/MainActivity.java
+++ b/MidiSynthExample/src/com/mobileer/midisynthexample/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends Activity {
 
         // Lock to portrait to avoid onCreate being called more than once.
         // TODO Use a Fragment to handle this more gracefully.
-        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+ //       setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
         mLatencyCheckBox = (CheckBox) findViewById(R.id.checkbox_low_latency);
         mOptimizeSizeCheckBox = (CheckBox) findViewById(R.id.checkbox_optimize);
@@ -151,6 +151,7 @@ public class MainActivity extends Activity {
         if (mPortSelector != null) {
             Log.i(TAG,"closeSynthResources() closing port ==========================");
             mPortSelector.close();
+            mPortSelector.onDestroy();
         }
     }
 

--- a/MidiTools/src/com/mobileer/miditools/MidiDeviceMonitor.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiDeviceMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Android Open Source Project
+ * Copyright (C) 2016 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MidiTools/src/com/mobileer/miditools/MidiDeviceMonitor.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiDeviceMonitor.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.miditools;
+
+import android.media.midi.MidiDeviceInfo;
+import android.media.midi.MidiDeviceStatus;
+import android.media.midi.MidiManager;
+import android.media.midi.MidiManager.DeviceCallback;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manage a list a of DeviceCallbacks that are called when a MIDI Device is
+ * plugged in or unplugged.
+ *
+ * This class is used to workaround a bug in the M release of the Android MIDI API.
+ * The MidiManager.unregisterDeviceCallback() method was not working. So if an app
+ * was rotated, and the Activity destroyed and recreated, the DeviceCallbacks would
+ * accumulate in the MidiServer. This would result in multiple callbacks whenever a
+ * device was added. This class allow an app to register and unregister multiple times
+ * using a local list of callbacks. It serves as a proxy to the MidiManager. It registers
+ * a single callback, which stays registered until the app is dead.
+ *
+ * This code checks to see if the N release is being used. N has a fix for the bug.
+ * For N, the register and unregister calls are passed directly to the MidiManager.
+ */
+public class MidiDeviceMonitor {
+    public final static String TAG = "MidiDeviceMonitor";
+    private MidiManager mMidiManager;
+    private static MidiDeviceMonitor instance;
+    private HashMap<DeviceCallback,Handler> mCallbacks = new HashMap<DeviceCallback,Handler>();
+    private MyDeviceCallback mMyDeviceCallback;
+    private boolean mUseProxy = Build.VERSION.SDK_INT <= Build.VERSION_CODES.M;
+
+    // Use an inner class so we do not clutter the API of MidiDeviceMonitor
+    // with public DeviceCallback methods.
+    protected class MyDeviceCallback extends DeviceCallback {
+
+        @Override
+        public void onDeviceAdded(final MidiDeviceInfo device) {
+            Log.i(TAG, "onDeviceAdded( " + device + ")");
+            // Call all of the locally registered callbacks.
+            for(Map.Entry<DeviceCallback, Handler> item : mCallbacks.entrySet()) {
+                DeviceCallback callback = item.getKey();
+                Handler handler = item.getValue();
+                if(handler == null) {
+                    callback.onDeviceAdded(device);
+                } else {
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.onDeviceAdded(device);
+                        }
+                    });
+                }
+            }
+        }
+
+        @Override
+        public void onDeviceRemoved(final MidiDeviceInfo device) {
+            Log.i(TAG, "onDeviceRemoved( " + device + ")");
+            for(Map.Entry<DeviceCallback, Handler> item : mCallbacks.entrySet()) {
+                DeviceCallback callback = item.getKey();
+                Handler handler = item.getValue();
+                if(handler == null) {
+                    callback.onDeviceRemoved(device);
+                } else {
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.onDeviceRemoved(device);
+                        }
+                    });
+                }
+            }
+        }
+
+        @Override
+        public void onDeviceStatusChanged(final MidiDeviceStatus status) {
+            Log.i(TAG, "onDeviceStatusChanged( " + status + ")");
+            for(Map.Entry<DeviceCallback, Handler> item : mCallbacks.entrySet()) {
+                DeviceCallback callback = item.getKey();
+                Handler handler = item.getValue();
+                if(handler == null) {
+                    callback.onDeviceStatusChanged(status);
+                } else {
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.onDeviceStatusChanged(status);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    private MidiDeviceMonitor(MidiManager midiManager) {
+        mMidiManager = midiManager;
+        if (mUseProxy) {
+            Log.i(TAG,"Running on M so we need to use the workaround.");
+            mMyDeviceCallback = new MyDeviceCallback();
+            mMidiManager.registerDeviceCallback(mMyDeviceCallback,
+                    new Handler(Looper.getMainLooper()));
+        }
+    }
+
+    public static MidiDeviceMonitor getInstance(MidiManager midiManager) {
+        if (instance == null) {
+            instance = new MidiDeviceMonitor(midiManager);
+        }
+        return instance;
+    }
+
+    public void registerDeviceCallback(DeviceCallback callback, Handler handler) {
+        if (mUseProxy) {
+            mCallbacks.put(callback, handler);
+        } else {
+            mMidiManager.registerDeviceCallback(callback, handler);
+        }
+    }
+
+    public void unregisterDeviceCallback(DeviceCallback callback) {
+        if (mUseProxy) {
+            mCallbacks.remove(callback);
+        } else {
+            mMidiManager.unregisterDeviceCallback(callback);
+        }
+    }
+}

--- a/MidiTools/src/com/mobileer/miditools/MidiDeviceMonitor.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiDeviceMonitor.java
@@ -125,7 +125,7 @@ public class MidiDeviceMonitor {
         }
     }
 
-    public static MidiDeviceMonitor getInstance(MidiManager midiManager) {
+    public synchronized static MidiDeviceMonitor getInstance(MidiManager midiManager) {
         if (mInstance == null) {
             mInstance = new MidiDeviceMonitor(midiManager);
         }

--- a/MidiTools/src/com/mobileer/miditools/MidiInputPortSelector.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiInputPortSelector.java
@@ -87,5 +87,6 @@ public class MidiInputPortSelector extends MidiPortSelector {
         } catch (IOException e) {
             Log.e(MidiConstants.TAG, "cleanup failed", e);
         }
+        super.onClose();
     }
 }

--- a/MidiTools/src/com/mobileer/miditools/MidiOutputPortConnectionSelector.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiOutputPortConnectionSelector.java
@@ -31,6 +31,7 @@ public class MidiOutputPortConnectionSelector extends MidiPortSelector {
     private MidiPortConnector mSynthConnector;
     private MidiDeviceInfo mDestinationDeviceInfo;
     private int mDestinationPortIndex;
+    private MidiPortWrapper mLastWrapper;
     private MidiPortConnector.OnPortsConnectedListener mConnectedListener;
 
     /**
@@ -53,16 +54,18 @@ public class MidiOutputPortConnectionSelector extends MidiPortSelector {
 
     @Override
     public void onPortSelected(final MidiPortWrapper wrapper) {
-        Log.i(TAG, "================ onPortSelected: " + wrapper);
-        onClose();
-        if (wrapper.getDeviceInfo() != null) {
-            mSynthConnector = new MidiPortConnector(mMidiManager);
-            mSynthConnector.connectToDevicePort(wrapper.getDeviceInfo(),
-                    wrapper.getPortIndex(), mDestinationDeviceInfo,
-                    mDestinationPortIndex,
-                    // not safe on UI thread
-                    mConnectedListener, null);
+        if(!wrapper.equals(mLastWrapper)) {
+            onClose();
+            if (wrapper.getDeviceInfo() != null) {
+                mSynthConnector = new MidiPortConnector(mMidiManager);
+                mSynthConnector.connectToDevicePort(wrapper.getDeviceInfo(),
+                        wrapper.getPortIndex(), mDestinationDeviceInfo,
+                        mDestinationPortIndex,
+                        // not safe on UI thread
+                        mConnectedListener, null);
+            }
         }
+        mLastWrapper = wrapper;
     }
 
     @Override

--- a/MidiTools/src/com/mobileer/miditools/MidiOutputPortConnectionSelector.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiOutputPortConnectionSelector.java
@@ -27,17 +27,20 @@ import java.io.IOException;
  * Select an output port and connect it to a destination input port.
  */
 public class MidiOutputPortConnectionSelector extends MidiPortSelector {
-
+    public final static String TAG = "MidiOutputPortConnectionSelector";
     private MidiPortConnector mSynthConnector;
     private MidiDeviceInfo mDestinationDeviceInfo;
     private int mDestinationPortIndex;
     private MidiPortConnector.OnPortsConnectedListener mConnectedListener;
 
     /**
+     * Create a selector for connecting to the destination input port.
+     *
      * @param midiManager
      * @param activity
      * @param spinnerId
-     * @param type
+     * @param destinationDeviceInfo
+     * @param destinationPortIndex
      */
     public MidiOutputPortConnectionSelector(MidiManager midiManager,
             Activity activity, int spinnerId,
@@ -50,7 +53,7 @@ public class MidiOutputPortConnectionSelector extends MidiPortSelector {
 
     @Override
     public void onPortSelected(final MidiPortWrapper wrapper) {
-        Log.i(MidiConstants.TAG, "connectPortToSynth: " + wrapper);
+        Log.i(TAG, "================ onPortSelected: " + wrapper);
         onClose();
         if (wrapper.getDeviceInfo() != null) {
             mSynthConnector = new MidiPortConnector(mMidiManager);
@@ -72,10 +75,11 @@ public class MidiOutputPortConnectionSelector extends MidiPortSelector {
         } catch (IOException e) {
             Log.e(MidiConstants.TAG, "Exception in closeSynthResources()", e);
         }
+        super.onClose();
     }
 
     /**
-     * @param myPortsConnectedListener
+     * @param connectedListener
      */
     public void setConnectedListener(
             MidiPortConnector.OnPortsConnectedListener connectedListener) {

--- a/MidiTools/src/com/mobileer/miditools/MidiOutputPortSelector.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiOutputPortSelector.java
@@ -30,6 +30,7 @@ import java.io.IOException;
  * Manages a Spinner for selecting a MidiOutputPort.
  */
 public class MidiOutputPortSelector extends MidiPortSelector {
+    public final static String TAG = "MidiOutputPortSelector";
     private MidiOutputPort mOutputPort;
     private MidiDispatcher mDispatcher = new MidiDispatcher();
     private MidiDevice mOpenDevice;
@@ -46,7 +47,8 @@ public class MidiOutputPortSelector extends MidiPortSelector {
 
     @Override
     public void onPortSelected(final MidiPortWrapper wrapper) {
-        Log.i(MidiConstants.TAG, "onPortSelected: " + wrapper);
+        Log.i(TAG, "================ onPortSelected: " + wrapper);
+        new RuntimeException("FIXME - select port").printStackTrace();
         close();
 
         final MidiDeviceInfo info = wrapper.getDeviceInfo();
@@ -87,6 +89,7 @@ public class MidiOutputPortSelector extends MidiPortSelector {
         } catch (IOException e) {
             Log.e(MidiConstants.TAG, "cleanup failed", e);
         }
+        super.onClose();
     }
 
     /**

--- a/MidiTools/src/com/mobileer/miditools/MidiOutputPortSelector.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiOutputPortSelector.java
@@ -47,8 +47,6 @@ public class MidiOutputPortSelector extends MidiPortSelector {
 
     @Override
     public void onPortSelected(final MidiPortWrapper wrapper) {
-        Log.i(TAG, "================ onPortSelected: " + wrapper);
-        new RuntimeException("FIXME - select port").printStackTrace();
         close();
 
         final MidiDeviceInfo info = wrapper.getDeviceInfo();

--- a/MidiTools/src/com/mobileer/miditools/MidiPortConnector.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiPortConnector.java
@@ -36,7 +36,7 @@ public class MidiPortConnector {
     private MidiConnection mConnection;
 
     /**
-     * @param mMidiManager
+     * @param midiManager
      */
     public MidiPortConnector(MidiManager midiManager) {
         mMidiManager = midiManager;
@@ -100,11 +100,14 @@ public class MidiPortConnector {
 
     /**
      * Open two devices and connect their ports.
+     * Then notify listener of the result.
      *
      * @param sourceDeviceInfo
      * @param sourcePortIndex
      * @param destinationDeviceInfo
      * @param destinationPortIndex
+     * @param listener
+     * @param handler
      */
     public void connectToDevicePort(final MidiDeviceInfo sourceDeviceInfo,
             final int sourcePortIndex,

--- a/MidiTools/src/com/mobileer/miditools/MidiPortSelector.java
+++ b/MidiTools/src/com/mobileer/miditools/MidiPortSelector.java
@@ -79,7 +79,7 @@ public abstract class MidiPortSelector extends DeviceCallback {
                 });
         mSpinner.setAdapter(mAdapter);
 
-        mMidiManager.registerDeviceCallback(this,
+        MidiDeviceMonitor.getInstance(mMidiManager).registerDeviceCallback(this,
                 new Handler(Looper.getMainLooper()));
 
         MidiDeviceInfo[] infos = mMidiManager.getDevices();
@@ -107,7 +107,7 @@ public abstract class MidiPortSelector extends DeviceCallback {
         for (int i = 0; i < portCount; ++i) {
             MidiPortWrapper wrapper = new MidiPortWrapper(info, mType, i);
             mAdapter.add(wrapper);
-            Log.i(MidiConstants.TAG, wrapper + " was added");
+            Log.i(MidiConstants.TAG, wrapper + " was added to " + this);
             mAdapter.notifyDataSetChanged();
         }
     }
@@ -172,7 +172,15 @@ public abstract class MidiPortSelector extends DeviceCallback {
     /**
      * Implement this method to clean up any open resources.
      */
-    public abstract void onClose();
+    public void onClose() {
+    }
+
+    /**
+     * Implement this method to clean up any open resources.
+     */
+    public void onDestroy() {
+        MidiDeviceMonitor.getInstance(mMidiManager).unregisterDeviceCallback(this);
+    }
 
     /**
      *

--- a/README.md
+++ b/README.md
@@ -2,40 +2,38 @@
 
 ## Introduction
 
-Android MIDI test programs and examples.
+Android MIDI API test programs and examples that run on
+Android M or later.
+
+These are primary examples for developers to learn from.
+
+These may also be useful for OEMs to test MIDI on new devices.
 
 This is not an official Google product.
 
-This is a suite of MIDI Apps that run on Android M or later.
+## Apps
 
-They are intended for use by OEMs for testing MIDI
-on new devices. But they may also be of use to
-other developers.
+These apps can also be downloaded from the Google Play App Store.
 
-## Building
+MidiScope displays MIDI Messages on the screen.
+https://play.google.com/store/apps/details?id=com.mobileer.example.midiscope
 
-Requires a platform build environment; see
-[Building the System](https://source.android.com/source/building.html)
+MidiKeyboard display a simple on-screen music keyboard.
+https://play.google.com/store/apps/details?id=com.mobileer.midikeyboard
 
-After your platform build environment is initialized, type:
+MidiSynthExample is a simple sawtooth MIDI synthesizer.
+https://play.google.com/store/apps/details?id=com.mobileer.midisynthexample
 
-```
-mm
-```
+MidiBtlePairing pairs with Bluetooth MIDI devices.
+https://play.google.com/store/apps/details?id=com.mobileer.example.midibtlepairing
 
-The resulting APKs are located in $OUT/data/app/Midi\*/Midi\*.apk
+See the README files in the App directories for more information.
 
-## Directories
+## Library
 
 The MidiTools folder contain general purpose MIDI classes
 that are used by the other Apps.
 
-MidiScope displays MIDI Messages on the screen.
+## Building for App Developers
 
-MidiKeyboard display a simple on-screen music keyboard.
-
-MidiSynthExample is a simple sawtooth MIDI synthesizer.
-
-MidiBtlePairing pairs with Bluetooth MIDI devices.
-
-See the README files in the App directories for more information.
+You can load this project into Android Studio and build it there.


### PR DESCRIPTION
In M the MidiManager.unregisterDeviceCallback() method does nothing.
As a workaround this code manages a local list of callbacks.
Also fixes a problem with creating multiple FakeKeyGenerators, which was causing SecurityException spew.
