### PR TITLE
FakeKeyGenerator: catch SecurityException

### DIFF
--- a/MidiSynthExample/AndroidManifest.xml
+++ b/MidiSynthExample/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.mobileer.midisynthexample"
-        android:versionCode="4"
+        android:versionCode="5"
         android:versionName="@string/versionName">
 
     <uses-sdk

--- a/MidiSynthExample/res/values/strings.xml
+++ b/MidiSynthExample/res/values/strings.xml
@@ -16,7 +16,7 @@
 
 <resources>
 
-    <string name="versionName">1.3</string>
+    <string name="versionName">1.4</string>
     <string name="synth_sender_text">Select Sender for Synth</string>
     <string name="error_port_busy">Selected port is in use or unavailable.</string>
     <string name="port_open_ok">Port opened OK.</string>


### PR DESCRIPTION
Injecting fake touches can sometimes generate a SecurityException
if the event goes to the wrong app.