### PR TITLE
MidiKeyboard: remove "extends Activity" from listener

### DIFF
--- a/MidiKeyboard/src/com/mobileer/midikeyboard/MainActivity.java
+++ b/MidiKeyboard/src/com/mobileer/midikeyboard/MainActivity.java
@@ -50,7 +50,7 @@ public class MainActivity extends Activity {
     private int[] mPrograms = new int[MidiConstants.MAX_CHANNELS]; // ranges from 0 to 127
     private byte[] mByteBuffer = new byte[3];
 
-    public class ChannelSpinnerActivity extends Activity implements AdapterView.OnItemSelectedListener {
+    public class ChannelSpinnerActivity implements AdapterView.OnItemSelectedListener {
         @Override
         public void onItemSelected(AdapterView<?> parent, View view,
                                    int pos, long id) {


### PR DESCRIPTION
Was copy and pasted from example. Not needed.