### PR TITLE
use Spinner Context to create ArrayAdapter

### DIFF
--- a/miditools/src/main/java/com/mobileer/miditools/MidiPortSelector.java
+++ b/miditools/src/main/java/com/mobileer/miditools/MidiPortSelector.java
@@ -56,13 +56,13 @@ public abstract class MidiPortSelector extends DeviceCallback {
         mMidiManager = midiManager;
         mActivity = activity;
         mType = type;
-        mAdapter = new ArrayAdapter<MidiPortWrapper>(activity,
+        mSpinner = (Spinner) activity.findViewById(spinnerId);
+        mAdapter = new ArrayAdapter<>(mSpinner.getContext(),
                 android.R.layout.simple_spinner_item);
         mAdapter.setDropDownViewResource(
                 android.R.layout.simple_spinner_dropdown_item);
         mAdapter.add(new MidiPortWrapper(null, 0, 0));
 
-        mSpinner = (Spinner) activity.findViewById(spinnerId);
         mSpinner.setOnItemSelectedListener(
                 new AdapterView.OnItemSelectedListener() {
 


### PR DESCRIPTION
this is need to allow the View created by the Adapter to inherit the same Theme as the Spinner.

ie: if you put the Spinner in the Toolbar with a Theme.AppCompat.Light.DarkActionBar , the view inflated by the Adapter have black text color, where it should be white.