### PR TITLE
MidiKeyboard: Fix NullPointerException

### DIFF
--- a/MidiKeyboard/src/main/java/com/mobileer/midikeyboard/MainActivity.java
+++ b/MidiKeyboard/src/main/java/com/mobileer/midikeyboard/MainActivity.java
@@ -170,14 +170,16 @@ public class MainActivity extends Activity {
     }
 
     private void midiSend(byte[] buffer, int count, long timestamp) {
-        try {
-            // send event immediately
-            MidiReceiver receiver = mKeyboardReceiverSelector.getReceiver();
-            if (receiver != null) {
-                receiver.send(buffer, 0, count, timestamp);
+        if (mKeyboardReceiverSelector != null) {
+            try {
+                // send event immediately
+                MidiReceiver receiver = mKeyboardReceiverSelector.getReceiver();
+                if (receiver != null) {
+                    receiver.send(buffer, 0, count, timestamp);
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "mKeyboardReceiverSelector.send() failed " + e);
             }
-        } catch (IOException e) {
-            Log.e(TAG, "mKeyboardReceiverSelector.send() failed " + e);
         }
     }
 }


### PR DESCRIPTION
May be caused by not supporting MIDI feature.
Fix involves checking for null object.

Fixes #42