### PR TITLE
SynthExample: use low latency by default

### DIFF
--- a/MidiSynthExample/build.gradle
+++ b/MidiSynthExample/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 def versionMajor = 1
-def versionMinor = 5
+def versionMinor = 6
 
 android {
     compileSdkVersion 29

--- a/MidiTools/src/main/java/com/mobileer/miditools/synth/LatencyController.java
+++ b/MidiTools/src/main/java/com/mobileer/miditools/synth/LatencyController.java
@@ -20,8 +20,9 @@ package com.mobileer.miditools.synth;
  * Abstract control over the audio latency.
  */
 public abstract class LatencyController {
-    private boolean mLowLatencyEnabled;
-    private boolean mAutoSizeEnabled;
+    // Set these true so we get low latency even when run as a Service.
+    private boolean mLowLatencyEnabled = true;
+    private boolean mAutoSizeEnabled = true;
 
     public void setLowLatencyEnabled(boolean enabled) {
         mLowLatencyEnabled = enabled;


### PR DESCRIPTION
This will reduce latency when the synth is run as a service from
a keyboard app.

Also bump version to 1.6

Fixes #51